### PR TITLE
Add GitHub actions

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,37 @@
+name: Publish nightly build artifacts
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  build_and_publish:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ghidra: ["9.2", "9.2.1", "9.2.2", "9.2.3", "9.2.4"]
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-java@v1
+        with:
+          java-version: "11"
+          java-package: jdk
+          architecture: x64
+      - uses: er28-0652/setup-ghidra@master
+        with:
+          version: ${{ matrix.ghidra }}
+      - uses: eskatos/gradle-command-action@v1
+        with:
+          gradle-version: 6.9
+          arguments: test -PGHIDRA_INSTALL_DIR=${{ env.GHIDRA_INSTALL_DIR }}
+      - uses: eskatos/gradle-command-action@v1
+        with:
+          gradle-version: 6.9
+          arguments: buildExtension -PGHIDRA_INSTALL_DIR=${{ env.GHIDRA_INSTALL_DIR }}
+      - uses: svenstaro/upload-release-action@v1-release
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: dist/*Ghidra-CodeWarriorDemangler.zip
+          tag: "latest"
+          overwrite: true
+          file_glob: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: Run tests
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ghidra: ["9.2", "9.2.1", "9.2.2", "9.2.3", "9.2.4"]
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-java@v1
+        with:
+          java-version: "11"
+          java-package: jdk
+          architecture: x64
+      - uses: er28-0652/setup-ghidra@master
+        with:
+          version: ${{ matrix.ghidra }}
+      - uses: eskatos/gradle-command-action@v1
+        with:
+          gradle-version: 6.9
+          arguments: test -PGHIDRA_INSTALL_DIR=${{ env.GHIDRA_INSTALL_DIR }}

--- a/build.gradle
+++ b/build.gradle
@@ -1,26 +1,79 @@
-apply from: "$rootProject.projectDir/gradle/javaProject.gradle"
+// Builds a Ghidra Extension for a given Ghidra installation.
+//
+// An absolute path to the Ghidra installation directory must be supplied either by setting the 
+// GHIDRA_INSTALL_DIR environment variable or Gradle project property:
+//
+//     > export GHIDRA_INSTALL_DIR=<Absolute path to Ghidra> 
+//     > gradle
+//
+//         or
+//
+//     > gradle -PGHIDRA_INSTALL_DIR=<Absolute path to Ghidra>
+//
+// Gradle should be invoked from the directory of the project to build.  Please see the
+// application.gradle.version property in <GHIDRA_INSTALL_DIR>/Ghidra/application.properties
+// for the correction version of Gradle to use for the Ghidra installation you specify.
+
+apply plugin: 'java'
 apply plugin: 'eclipse'
 
+//----------------------START "DO NOT MODIFY" SECTION------------------------------
+def ghidraInstallDir
 
-eclipse.project.name = '_Skeleton'
-
-dependencies {
-	compile project(':Base')
+if (System.env.GHIDRA_INSTALL_DIR) {
+    ghidraInstallDir = System.env.GHIDRA_INSTALL_DIR
+}
+else if (project.hasProperty("GHIDRA_INSTALL_DIR")) {
+    ghidraInstallDir = project.getProperty("GHIDRA_INSTALL_DIR")
 }
 
-// We don't want this to build
-compileJava.enabled = false
-jar.enabled = false
+if (ghidraInstallDir) {
+    apply from: new File(ghidraInstallDir).getCanonicalPath() + "/support/buildExtension.gradle"
+}
+else {
+    throw new GradleException("GHIDRA_INSTALL_DIR is not defined!")
+}
+//----------------------END "DO NOT MODIFY" SECTION-------------------------------
 
-// NOTE: In a build, this file will get replaced by buildTemplate.gradle. 
-rootProject.assembleDistribution {
-	from (this.projectDir) {
-		exclude 'bin'
-		exclude 'build'
-		exclude 'ghidra_scripts/bin/'
-		exclude '.classpath'
-		exclude '.project'
-		rename "buildTemplate.gradle", "build.gradle"
-		into "Extensions/Ghidra/Skeleton"
+repositories { mavenCentral() }
+
+dependencies {
+	testCompile "org.hamcrest:hamcrest-all:1.3"
+	testCompile "org.jmockit:jmockit:1.44"
+	testCompile "junit:junit:4.12"
+	runtimeOnly fileTree(dir: ghidraInstallDir + '/Ghidra/Framework', include: "**/*.jar")
+	runtimeOnly fileTree(dir: ghidraInstallDir + '/Ghidra/Features', include: "**/*.jar")
+	compileOnly fileTree(dir: ghidraInstallDir + '/Ghidra/Processors', include: "**/*.jar")
+}
+
+if (ghidra_version < "9.2") {
+    throw new GradleException("Requires at least Ghidra 9.2, but was run with $ghidra_version")
+}
+
+test {
+    useJUnit()
+
+    maxHeapSize = '1G'
+}
+
+eclipse.classpath.file.whenMerged {
+	File javaDoc = new File(ghidraInstallDir+"/docs/GhidraAPI_javadoc.zip");
+	def destroy = [];
+	for (entry in entries) {
+		if (entry.getPath().toString().contains("codewarriordemangler")) {
+			destroy.add(entry);
+			continue;
+		} else if (entry.path.contains('jar')) {
+			File folder = new File(entry.getPath()).getParentFile();
+			for (File file : folder.listFiles()) {
+				if (file.getName().endsWith(".zip")) {
+					entry.setSourcePath(it.fileReference(file));
+					entry.setJavadocPath(it.fileReference(javaDoc));
+				}
+			}
+		}
+	}
+	for (entry in destroy) {
+		entries.remove(entry);
 	}
 }

--- a/extension.properties
+++ b/extension.properties
@@ -1,5 +1,5 @@
 name=@extname@
 description=Code Warrior Demangler Extension for Ghidra
 author=Cuyler36
-createdOn=14/11/2020
+createdOn=
 version=@extversion@


### PR DESCRIPTION
This was barely tested! However, end-result looks like this: https://github.com/JayFoxRox/Ghidra-CodeWarriorDemangler/releases/tag/latest

---

Attempt at automating releases, by simply copy and pasting the GitHub actions workflows from https://github.com/beardypig/ghidra-emotionengine/tree/master/.github/workflows (namely https://github.com/beardypig/ghidra-emotionengine/pull/65).

I also had to copy build.gradle but I have no clue about Gradle, so I'm not sure wether this is an acceptable solution.
I did the bare minimum changes which looked right.

For future developments of the workflows check out https://github.com/beardypig/ghidra-emotionengine/issues/67 which should enable to auto-release for each new Ghidra release.