### PR TITLE
Wrong build.gradle is being used

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,26 +1,48 @@
-apply from: "$rootProject.projectDir/gradle/javaProject.gradle"
-apply plugin: 'eclipse'
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Builds a Ghidra Extension for a given Ghidra installation.
+//
+// An absolute path to the Ghidra installation directory must be supplied either by setting the 
+// GHIDRA_INSTALL_DIR environment variable or Gradle project property:
+//
+//     > export GHIDRA_INSTALL_DIR=<Absolute path to Ghidra> 
+//     > gradle
+//
+//         or
+//
+//     > gradle -PGHIDRA_INSTALL_DIR=<Absolute path to Ghidra>
+//
+// Gradle should be invoked from the directory of the project to build.  Please see the
+// application.gradle.version property in <GHIDRA_INSTALL_DIR>/Ghidra/application.properties
+// for the correction version of Gradle to use for the Ghidra installation you specify.
 
+//----------------------START "DO NOT MODIFY" SECTION------------------------------
+def ghidraInstallDir
 
-eclipse.project.name = '_Skeleton'
-
-dependencies {
-	compile project(':Base')
+if (System.env.GHIDRA_INSTALL_DIR) {
+	ghidraInstallDir = System.env.GHIDRA_INSTALL_DIR
+}
+else if (project.hasProperty("GHIDRA_INSTALL_DIR")) {
+	ghidraInstallDir = project.getProperty("GHIDRA_INSTALL_DIR")
 }
 
-// We don't want this to build
-compileJava.enabled = false
-jar.enabled = false
-
-// NOTE: In a build, this file will get replaced by buildTemplate.gradle. 
-rootProject.assembleDistribution {
-	from (this.projectDir) {
-		exclude 'bin'
-		exclude 'build'
-		exclude 'ghidra_scripts/bin/'
-		exclude '.classpath'
-		exclude '.project'
-		rename "buildTemplate.gradle", "build.gradle"
-		into "Extensions/Ghidra/Skeleton"
-	}
+if (ghidraInstallDir) {
+	apply from: new File(ghidraInstallDir).getCanonicalPath() + "/support/buildExtension.gradle"
 }
+else {
+	throw new GradleException("GHIDRA_INSTALL_DIR is not defined!")
+}
+//----------------------END "DO NOT MODIFY" SECTION-------------------------------


### PR DESCRIPTION
Ghidra recently had a bug that put the wrong `build.gradle` into the Skeleton template that is used to create new extensions.  It has been fixed for the upcoming 10.0 release.  This PR manually updates your `build.gradle` to the correct version.

https://github.com/NationalSecurityAgency/ghidra/issues/3115#issuecomment-857617916